### PR TITLE
updated chart version to include horizon lua fix

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: microservice
 description: A Helm chart for Kubernetes
-version: "0.0.3"
+version: "0.0.4"


### PR DESCRIPTION
#### Is this a new chart?
- [ ] Yes
- [ x] No, but chart version bumped

<br>

#### Overview of changes:

Bumping the chart version to incorporate the new syntax for the lua extension (there was a typo in the relase 0.0.3 update) 

#### Special notes for your reviewer:

<br>

#### Checklist
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)