### PR TITLE
37 bug node apps must be on port 3000

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "0.1.0"
+version: "0.1.1"

--- a/charts/node/templates/deployment.yaml
+++ b/charts/node/templates/deployment.yaml
@@ -51,14 +51,14 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.application.ports.containerPort | default 3000 }}
+              containerPort: {{ .Values.application.ports.containerPort }} 
               protocol: TCP
           resources:
             {{- toYaml .Values.application.resources | nindent 12 }}
           livenessProbe:
             {{- if eq .Values.application.livenessProbe.type "tcp" }}
             tcpSocket:
-              port: {{ .Values.application.livenessProbe.port | default 3000 }} 
+              port: {{ .Values.application.livenessProbe.port  }} 
             {{- else }}
             httpGet:
               port: 3000
@@ -69,7 +69,7 @@ spec:
           readinessProbe:
             {{- if eq .Values.application.readinessProbe.type "tcp" }}
             tcpSocket:
-              port: {{ .Values.application.readinessProbe.port | default 3000 }} 
+              port: {{ .Values.application.readinessProbe.port  }} 
             {{- else }}
             httpGet:
               port: 3000

--- a/charts/node/templates/deployment.yaml
+++ b/charts/node/templates/deployment.yaml
@@ -51,14 +51,14 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.application.ports.containerPort | default 3000 }}
               protocol: TCP
           resources:
             {{- toYaml .Values.application.resources | nindent 12 }}
           livenessProbe:
             {{- if eq .Values.application.livenessProbe.type "tcp" }}
             tcpSocket:
-              port: 3000
+              port: {{ .Values.application.livenessProbe.port | default 3000 }} 
             {{- else }}
             httpGet:
               port: 3000
@@ -69,7 +69,7 @@ spec:
           readinessProbe:
             {{- if eq .Values.application.readinessProbe.type "tcp" }}
             tcpSocket:
-              port: 3000
+              port: {{ .Values.application.readinessProbe.port | default 3000 }} 
             {{- else }}
             httpGet:
               port: 3000

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -9,18 +9,22 @@ application:
   # -- Any args that need to be supplied to the `ENTRYPOINT` command.
   args: []
   extraVolumes: []
+  ports:
+    containerPort: 3000
   healthcheck:
     path: ""
     headers: ""
   livenessProbe:
     # -- Type of liveness healthcheck. `http` or `tcp`
     type: http
+    port: 3000
     path: /_/system/liveness
     # -- Custom headers to set in the request. HTTP allows repeated headers.
     httpHeaders: []
   readinessProbe:
     # -- Type of readiness healthcheck. `http` or `tcp`
     type: http
+    port: 3000
     path: /_/system/readiness
     # -- Custom headers to set in the request. HTTP allows repeated headers.
     httpHeaders: []


### PR DESCRIPTION
Added default value of 3000 for the container port plus liveness & readiness checks, enabling them to be overridden by specific values in the application's values file 