### PR TITLE
feat(go): support HTTP services and distroless images

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.2.1"
+version: "1.3.0"

--- a/charts/go/templates/_application.tpl
+++ b/charts/go/templates/_application.tpl
@@ -16,11 +16,44 @@ Define the container image urls
 Define container security context
 */}}
 {{- define "go.application.securityContext" -}}
-runAsUser: 1000
-runAsGroup: 1000
+runAsUser: {{ .Values.application.securityContext.runAsUser }}
+runAsGroup: {{ .Values.application.securityContext.runAsGroup }}
 runAsNonRoot: true
 readOnlyRootFilesystem: {{ .Values.application.readOnly }}
 allowPrivilegeEscalation: false
+{{- end }}
+
+{{/*
+Renders a probe. gRPC services (deployment.grpc: true) use the grpc_health_probe
+binary; everything else uses an HTTP GET against the container port. Pass the
+probe config in as "probe" and the root context as "ctx".
+*/}}
+{{- define "go.application.probe" -}}
+{{- $ctx := .ctx -}}
+{{- $probe := .probe -}}
+{{- if $ctx.Values.deployment.grpc -}}
+exec:
+  command: ["/go/bin/grpc_health_probe", "-addr=:{{ $ctx.Values.deployment.containerPort }}"]
+{{- else if eq $probe.type "tcp" -}}
+tcpSocket:
+  port: {{ $ctx.Values.deployment.containerPort }}
+{{- else -}}
+httpGet:
+  port: {{ $ctx.Values.deployment.containerPort }}
+  path: {{ $probe.path }}
+  {{- with $probe.httpHeaders }}
+  httpHeaders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+initialDelaySeconds: {{ $probe.initialDelaySeconds }}
+timeoutSeconds: {{ $probe.timeoutSeconds }}
+{{- with $probe.periodSeconds }}
+periodSeconds: {{ . }}
+{{- end }}
+{{- with $probe.failureThreshold }}
+failureThreshold: {{ . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
           image: "{{ include "go.application.imageURL" . }}"
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           securityContext: {{ include "go.application.securityContext" . | nindent 12 }}
+          {{- with .Values.application.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APP_NAME
               value: {{ .Values.application.name | lower | quote }}
@@ -50,20 +54,18 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 50051
+              containerPort: {{ .Values.deployment.containerPort }}
               protocol: TCP
           resources:
             {{- toYaml .Values.application.resources | nindent 12 }}
+          {{- if .Values.application.startupProbe.enabled }}
+          startupProbe:
+            {{- include "go.application.probe" (dict "ctx" . "probe" .Values.application.startupProbe) | nindent 12 }}
+          {{- end }}
           livenessProbe:
-            exec:
-              command: ["/go/bin/grpc_health_probe", "-addr=:50051"]
-            initialDelaySeconds: 10
-            timeoutSeconds: 5
+            {{- include "go.application.probe" (dict "ctx" . "probe" .Values.application.livenessProbe) | nindent 12 }}
           readinessProbe:
-            exec:
-              command: ["/go/bin/grpc_health_probe", "-addr=:50051"]
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
+            {{- include "go.application.probe" (dict "ctx" . "probe" .Values.application.readinessProbe) | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
@@ -71,7 +73,7 @@ spec:
             {{- include "go.application.extraConfigmapMounts" . | nindent 12 }}
             {{- end }}
       securityContext:
-        fsGroup: 1000
+        fsGroup: {{ .Values.application.securityContext.fsGroup }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/go/templates/job.yaml
+++ b/charts/go/templates/job.yaml
@@ -38,10 +38,13 @@ spec:
         - name: {{ include "go.application.name" . }}
           image: {{ include "go.application.imageURL" . }}
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
-{{/*          args: [ "schedule" ]*/}}
+          {{- with .Values.job.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
-            runAsUser: 1000 # User "app" within the container
-            runAsGroup: 1000
+            runAsUser: {{ .Values.application.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.application.securityContext.runAsGroup }}
             runAsNonRoot: true
             readOnlyRootFilesystem: true
           resources:

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -13,18 +13,45 @@ application:
   healthcheck:
     path: ""
     headers: ""
+  # -- Container security context. Defaults suit the standard alpine-based images
+  # (user "app"). Distroless images run as 65532.
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  # -- Optional startup probe, for apps that need longer to warm up than the
+  # liveness probe tolerates. Uses the same shape as the probes below.
+  startupProbe:
+    enabled: false
+    type: http
+    path: /_/system/liveness
+    httpHeaders: []
+    initialDelaySeconds: 0
+    timeoutSeconds: 2
+    periodSeconds: 3
+    failureThreshold: 20
+  # -- Ignored when `deployment.grpc` is true, in which case grpc_health_probe is used.
   livenessProbe:
     # -- Type of liveness healthcheck. `http` or `tcp`
     type: http
     path: /_/system/liveness
     # -- Custom headers to set in the request. HTTP allows repeated headers.
     httpHeaders: []
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: ""
+    failureThreshold: ""
+  # -- Ignored when `deployment.grpc` is true, in which case grpc_health_probe is used.
   readinessProbe:
     # -- Type of readiness healthcheck. `http` or `tcp`
     type: http
     path: /_/system/readiness
     # -- Custom headers to set in the request. HTTP allows repeated headers.
     httpHeaders: []
+    initialDelaySeconds: 5
+    timeoutSeconds: 1
+    periodSeconds: ""
+    failureThreshold: ""
   # -- Application environment variables. Currently, most of these should be stored in Vault and defined in Terragrunt.
   env: []
   # Configure container registry details
@@ -78,7 +105,12 @@ cloud:
 
 deployment:
   enabled: true
-  grpc: false
+  # -- Use gRPC health probes (`/go/bin/grpc_health_probe`) instead of the HTTP/TCP
+  # probes configured under `application`. Defaults true: every consumer of this
+  # chart predates HTTP support and is a gRPC service.
+  grpc: true
+  # -- Port the application listens on. gRPC services conventionally use 50051.
+  containerPort: 50051
   # Horizontal Pod Autoscaler configuration.
   hpa:
     enabled: true
@@ -127,7 +159,8 @@ job:
   annotations:
   vault:
     enabled: true
-  args: ""
+  # -- Args passed to the job container's entrypoint, e.g. `["migrations"]`.
+  args: []
   restartPolicy: "OnFailure"
   backoffLimit: 2
   resources:


### PR DESCRIPTION
## Problem

The `go` chart can only host **gRPC services listening on 50051**. `deployment.yaml` hardcodes both the port and the probes:

```yaml
containerPort: 50051
livenessProbe:  exec: ["/go/bin/grpc_health_probe", "-addr=:50051"]
readinessProbe: exec: ["/go/bin/grpc_health_probe", "-addr=:50051"]
```

An HTTP service adopting it gets probes that exec a binary its image doesn't contain — every pod CrashLoops. That's why `tenancy-go` and `tenancy-rs` both ship self-contained charts instead, duplicating ~10 templates each.

Notably `values.yaml` **already declares** `application.livenessProbe.type`/`path`, `readinessProbe.type`/`path` and `deployment.grpc` — no template ever read them. This PR mostly finishes wiring that existing contract rather than inventing one.

## Changes

| Value | Default | Purpose |
|---|---|---|
| `deployment.containerPort` | `50051` | replaces the hardcoded port; probes use it too |
| `deployment.grpc` | `true` | `grpc_health_probe` vs the configured HTTP/TCP probes |
| `application.livenessProbe.*` / `readinessProbe.*` | as before | now honoured; `periodSeconds`/`failureThreshold` added |
| `application.startupProbe.*` | `enabled: false` | optional, for slow warm-up (connection pools etc.) |
| `application.securityContext.{runAsUser,runAsGroup,fsGroup}` | `1000` | replaces hardcoded `1000`s; distroless needs `65532` |
| `application.args` | `[]` | passed to the container (was declared, never used) |
| `job.args` | `[]` | passed to the job (the line was commented out, so jobs couldn't run a subcommand) |

New helper `go.application.probe` renders a probe from its config, so the three probes share one implementation.

## Backwards compatibility

`deployment.grpc` defaults to **`true`**, which looks like a default flip but is the only safe choice: any existing consumer is necessarily a gRPC service on 50051, because the template offered no alternative. A consumer that had set `grpc: false` was getting gRPC probes anyway.

Proof — rendered `portfolio-calculations`' **real** `demo-west-values.yaml` (which sets `deployment.grpc: true`) against `1.2.1` and this branch:

```
diff <(norm render-1.2.1.yaml) <(norm render-1.3.0.yaml)
→ byte-identical
```

The only raw differences were the `chart: go-1.2.1` → `go-1.3.0` label and the chart's own `now()`-based `release-timestamp` annotation, both normalised above. Its probes still render as `exec: grpc_health_probe -addr=:50051` on `containerPort: 50051`.

`portfolio-calculations` pins `^1.0.0`, so it *will* consume this — hence the byte-level check rather than eyeballing.

`helm lint` passes on all four charts (`go`, `node`, `php`, `python`); only `go` is touched.

## Verified it now hosts an HTTP service

Rendering with `grpc: false`, `containerPort: 88`, `args: ["serve"]`, distroless `65532`, probes on `/livez` and `/readyz`, and `job.args: ["migrations"]` produces correct manifests — i.e. `tenancy-go` can drop its bespoke chart and depend on this instead. I'll raise that migration separately once this lands, rather than bundle a consumer change into a chart PR.

Minor version bump `1.2.1` → `1.3.0`: additive, no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)