### PR TITLE
feat(go): rollout strategy, preStop drain, VS timeout/retries, extra authz rules

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.3.0"
+version: "1.4.0"

--- a/charts/go/templates/authorization-policy.yaml
+++ b/charts/go/templates/authorization-policy.yaml
@@ -23,4 +23,7 @@ spec:
             {{- end }}
             {{- end }}
             ]
+    {{- with .Values.authorizationPolicy.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -9,6 +9,12 @@ metadata:
     {{- include "go.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
+  {{- with .Values.deployment.strategy }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ include "go.application.name" . }}"
@@ -66,6 +72,12 @@ spec:
             {{- include "go.application.probe" (dict "ctx" . "probe" .Values.application.livenessProbe) | nindent 12 }}
           readinessProbe:
             {{- include "go.application.probe" (dict "ctx" . "probe" .Values.application.readinessProbe) | nindent 12 }}
+          {{- with .Values.deployment.preStopSleepSeconds }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "{{ . }}"]
+          {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/charts/go/templates/job.yaml
+++ b/charts/go/templates/job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: {{ .Values.job.name }}
   annotations:
-    {{- toYaml .Values.job.annotations | nindent 12 }}
+    {{- toYaml .Values.job.annotations | nindent 4 }}
 spec:
   template:
     metadata:

--- a/charts/go/templates/virtual-service.yaml
+++ b/charts/go/templates/virtual-service.yaml
@@ -25,4 +25,11 @@ spec:
     - route:
         - destination:
             host: {{ include "go.application.name" . }}
+      {{- with .Values.virtualService.timeout }}
+      timeout: {{ . }}
+      {{- end }}
+      {{- with .Values.virtualService.retries }}
+      retries:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -73,6 +73,10 @@ application:
 
 authorizationPolicy:
   enabled: true
+  # -- Additional Istio AuthorizationPolicy rules, appended after the default
+  # allow-rule above. Use this to grant narrower access than the blanket rule —
+  # e.g. read-only principals on specific paths plus a separate admin rule.
+  extraRules: []
 
 # -- IAM Role to allow the application access to AWS resources (e.g. S3, SQS, Lambda) if needed.
 aws:
@@ -134,6 +138,12 @@ deployment:
 
   # -- Replica count not considering the HPA
   replicaCount: 3
+  # -- RollingUpdate parameters, e.g. `{maxSurge: 1, maxUnavailable: 0}` for
+  # zero-downtime rollouts. Omitted entirely when unset.
+  strategy: {}
+  # -- Seconds to sleep in a preStop hook, letting in-flight requests drain
+  # before the container is signalled. Omitted entirely when unset.
+  preStopSleepSeconds: ""
 
 destinationRule:
   enabled: true
@@ -219,3 +229,7 @@ virtualService:
   enabled: true
   gateways: []
   hosts: []
+  # -- Per-route request timeout, e.g. `2s`. Omitted entirely when unset.
+  timeout: ""
+  # -- Retry policy, e.g. `{attempts: 2, perTryTimeout: 2s}`. Omitted when unset.
+  retries: {}


### PR DESCRIPTION
Follow-up to #168 (1.3.0). Migrating `tenancy-go` onto the shared chart surfaced four things it still can't express — one of them a security regression — so this closes the gap. `1.3.0` → `1.4.0`.

## The blocker worth reading

`authorization-policy.yaml` emits a single rule with **no `to:` block**:

```yaml
rules:
  - from: [{ source: { principals: [prometheus, ...istio.principals] } }]
```

No `to:` means **every listed principal gets every method on every path**. For a service whose `principals` list is ~40 mesh callers, adopting the chart as-is would hand all of them `POST`/`PATCH`/`DELETE` on its write endpoints. `tenancy-go` currently splits read from write — GET on the read surface for `principals`, full `/api/v1/*` for a short `adminPrincipals` list — and would have silently lost that.

`authorizationPolicy.extraRules` (default `[]`) appends raw rules after the default one, so a service can express any narrower model without this chart taking a view on what that model should be.

## The other three

| Value | Default | Why |
|---|---|---|
| `deployment.strategy` | `{}` | `{maxSurge: 1, maxUnavailable: 0}` for zero-downtime rollouts — the chart previously emitted no `strategy` at all |
| `deployment.preStopSleepSeconds` | `""` | drain in-flight requests before SIGTERM |
| `virtualService.timeout` / `.retries` | `""` / `{}` | per-route mesh timeout and retry policy |

Also fixed: `job.yaml`'s annotations used `nindent 12` under `metadata.annotations`, rendering valid but badly over-indented YAML. No consumer set `job.annotations` before (it's needed for `helm.sh/hook` on migration jobs), so nothing changes.

## Backwards compatibility

Every addition is `{{- with }}`-guarded, so an unset value renders **nothing** — not an empty key. Proof, same method as #168: rendered `portfolio-calculations`' real `demo-west-values.yaml` against `1.3.0` and this branch →

```
diff <(norm r-130.yaml) <(norm r-140.yaml)   # byte-identical
```

`helm lint` passes on all four charts; only `go` is touched.

## Verified end state

With `1.4.0`, a full `tenancy-go` values file renders correctly for all of it: `containerPort: 88`, `args: ["serve"]`, distroless `65532`, HTTP probes on `/livez` + `/readyz` with a startup probe, `strategy` with `maxUnavailable: 0`, `preStop` sleep, VirtualService with `timeout: 2s` and 2 retries, the two-tier AuthorizationPolicy, and a migrations Job with `helm.sh/hook: pre-install,pre-upgrade` and `args: ["migrations"]` — 9 documents, all parsing.

That means `tenancy-go` can delete its 10 local templates and depend on this chart with **no loss of behaviour**. I'll raise that migration once this is released, same as we did for 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)