### PR TITLE
fix(go): render container env in the job, sharing one definition

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.4.0"
+version: "1.5.0"

--- a/charts/go/templates/_application.tpl
+++ b/charts/go/templates/_application.tpl
@@ -122,3 +122,22 @@ Extra volumes
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Container environment. Shared by the deployment and the job so a job running the
+same image gets the same configuration.
+*/}}
+{{- define "go.application.env" -}}
+- name: APP_NAME
+  value: {{ .Values.application.name | lower | quote }}
+- name: PLATFORM
+  value: "{{ include "go.cloud.provider" . }}"
+{{- if eq (include "go.cloud.provider" .) "AWS" }}
+- name: AWS_REGION
+  value: {{ .Values.cloud.region }}
+{{- end }}
+{{- range .Values.application.env }}
+- name: "{{ .name }}"
+  value: "{{ .value }}"
+{{- end }}
+{{- end }}

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -46,18 +46,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: PLATFORM
-              value: "{{ include "go.cloud.provider" . }}"
-            {{- if eq (include "go.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
-            {{- end }}
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- include "go.application.env" . | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.deployment.containerPort }}

--- a/charts/go/templates/job.yaml
+++ b/charts/go/templates/job.yaml
@@ -42,6 +42,8 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          env:
+            {{- include "go.application.env" . | nindent 12 }}
           securityContext:
             runAsUser: {{ .Values.application.securityContext.runAsUser }}
             runAsGroup: {{ .Values.application.securityContext.runAsGroup }}


### PR DESCRIPTION
Found while migrating `tenancy-go` onto the chart (third and final gap). `1.4.0` → `1.5.0`.

## Problem

`job.yaml` renders **no container `env` at all**. The job runs the same image as the deployment, so anything needing configuration gets none:

- a migrations job has no `DB_HOST` / `DB_DATABASE` / `DB_PORT`
- where secrets arrive via an injected file, no `ENV_FILE` telling the process where to read it

The Vault annotations are already on the job, so `/vault/secrets/env` is written — nothing tells the process to look at it. Concretely: `tenancy-go`'s migrations job would start, find no database configuration, and fail.

## Change

Extracts the deployment's env block into a `go.application.env` helper and uses it in both templates, so they can't drift:

```yaml
env:
  {{- include "go.application.env" . | nindent 12 }}
```

Same output as before for the deployment — `APP_NAME`, `PLATFORM`, `AWS_REGION` (AWS only), then `application.env`.

## Backwards compatibility

No consumer currently sets `job.enabled: true` (it defaults false, and `portfolio-calculations` — the only consumer of this chart — doesn't set it), so nothing gains env it didn't have.

Verified the deployment side is untouched: rendered `portfolio-calculations`' real `demo-west-values.yaml` against `1.4.0` and this branch → **byte-identical**. `helm lint` passes on all four charts.

## Context

This is the last of three gaps found by actually migrating a service rather than reading the chart:

- #168 (1.3.0) — HTTP probes, container port, args, distroless security context
- #169 (1.4.0) — rollout strategy, preStop drain, VS timeout/retries, extra authz rules
- this (1.5.0) — job env

With it, `tenancy-go` renders all 10 resources from the shared chart with no local templates and no behaviour loss. Migration PR follows once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)