### PR TITLE
fix(go): template the service targetPort

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.5.0"
+version: "1.5.1"

--- a/charts/go/templates/service.yaml
+++ b/charts/go/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
     - name: {{ ternary "grpc" "http" .Values.deployment.grpc }}
       protocol: TCP
       port: {{ .Values.service.port }}
-      targetPort: 50051
+      targetPort: {{ .Values.deployment.containerPort }}
   selector:
     app.kubernetes.io/name: {{ include "go.application.name" . }}
 {{- end }}


### PR DESCRIPTION
Bug I introduced in #168. `1.5.0` → `1.5.1`.

#168 made `deployment.containerPort` configurable in `deployment.yaml` but left `service.yaml` untouched:

```yaml
      targetPort: 50051   # hardcoded
```

So an HTTP service on any other port gets a Service routing `:80 → pod:50051`, where nothing is listening. The failure mode is nasty: pods pass their probes and look healthy, but every request through the Service — i.e. all in-cluster traffic and everything via the VirtualService — fails.

Caught while reviewing `tenancy-go`'s migration render (container port 88, Service `targetPort: 50051`).

```yaml
      targetPort: {{ .Values.deployment.containerPort }}
```

## Backwards compatibility

`containerPort` defaults to `50051`, so gRPC consumers render exactly as before — verified byte-identical for `portfolio-calculations`' real demo values between 1.5.0 and this branch. An HTTP service on 88 now correctly renders `port: 80, targetPort: 88`.

`helm lint` passes on all four charts.

Worth noting for review: this is the fourth gap found by migrating a real service, and the only one that would have deployed *silently* — the other three failed loudly at render or startup. If there's appetite, a `helm template` smoke test in CI asserting an HTTP-shaped values file produces a coherent Deployment+Service pair would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)