### PR TITLE
fix(go): PodDisruptionBudget uses policy/v1, not the removed v1beta1

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.5.1"
+version: "1.5.2"

--- a/charts/go/templates/pdb.yaml
+++ b/charts/go/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.pdb.enabled true }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "go.application.name" . }}


### PR DESCRIPTION
`1.5.1` → `1.5.2`. Found by a real deploy failing:

```
Error: unable to build kubernetes objects from release manifest:
resource mapping not found for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first
```

`policy/v1beta1` PodDisruptionBudget was **removed in Kubernetes 1.25**; `policy/v1` has existed since 1.21. One line:

```diff
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
```

No version gate needed — the clusters are clearly ≥1.25, since that's what produced the error.

## Why it went unnoticed

`pdb.enabled` defaults to `false`, and no consumer had set it. `portfolio-calculations` — the only other consumer of this chart — leaves it off, so `pdb.yaml` had never been rendered by anything.

Verified byte-identical for `portfolio-calculations`' real demo values between 1.5.1 and this branch. With `pdb.enabled: true` the PDB now renders correctly. `helm lint` passes on all four charts.

## ⚠️ Same line in `php` and `node`

```
charts/php/templates/pdb.yaml:2:apiVersion: policy/v1beta1
charts/node/templates/pdb.yaml:2:apiVersion: policy/v1beta1
```

Left untouched here: they version independently and have far more consumers, so they deserve their own PR and release rather than riding along on a `go` fix. Nobody is currently exposed — no php or node consumer sets `pdb.enabled` either — but the first one to try will hit exactly this. Happy to raise it if wanted.

Also noticed, not changed: `ingress.yaml` / `ingressv1.yaml` gate on `.Capabilities.KubeVersion.Minor` with **string** comparison (`le ... "21"`), so both render at exactly 1.21 and the ordering is lexical rather than numeric. Harmless on current clusters, worth tidying with `semverCompare` some day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)