### PR TITLE
feat(go): let the HPA memory target be an absolute value

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.5.2"
+version: "1.6.0"

--- a/charts/go/templates/hpa.yaml
+++ b/charts/go/templates/hpa.yaml
@@ -25,6 +25,10 @@ spec:
       resource:
         name: memory
         target:
-          type: Utilization
+          type: {{ .Values.deployment.hpa.targetMemoryType }}
+          {{- if eq .Values.deployment.hpa.targetMemoryType "AverageValue" }}
+          averageValue: {{ .Values.deployment.hpa.targetMemory }}
+          {{- else }}
           averageUtilization: {{ .Values.deployment.hpa.targetMemory }}
+          {{- end }}
 {{- end }}

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -124,8 +124,14 @@ deployment:
     minReplicas: 3
     # -- Target CPU usage (%)
     targetCPU: 70
-    # -- Target Memory usage (Mi). Default is `(request+limit) / 2`. Feel free to overwrite that here if necessary.
+    # -- Target Memory. Interpreted per `targetMemoryType`: a percentage of the
+    # memory *request* for `Utilization`, or an absolute quantity like `350Mi` for
+    # `AverageValue`.
     targetMemory: 70
+    # -- How `targetMemory` is interpreted: `Utilization` (percentage) or
+    # `AverageValue` (absolute quantity). `averageUtilization` takes an integer, so
+    # a value like `350Mi` requires `AverageValue`.
+    targetMemoryType: Utilization
   # Specify what type of node you want this app to be deployed on: ["cpu", "memory"]
   nodeSelector:
     toleration: ""


### PR DESCRIPTION
`1.5.2` → `1.6.0`. Caught by validating rendered output before deploying, rather than by the deploy failing.

## Problem

The HPA memory metric is hardcoded:

```yaml
name: memory
target:
  type: Utilization
  averageUtilization: {{ .Values.deployment.hpa.targetMemory }}
```

`averageUtilization` is an **int32 percentage of the memory request**. A service passing an absolute quantity — `350Mi`, which is what a memory threshold naturally looks like — renders `averageUtilization: 350Mi`, which the API server rejects on type. It renders fine, so `helm template` and `helm lint` both pass; it fails at apply, and with `--atomic` that's a rollback.

Not hypothetical: `tenancy-go`'s pre-migration chart used `type: AverageValue` / `averageValue: 350Mi`, and carrying those values onto this chart produced exactly the broken output.

## Change

```yaml
target:
  type: {{ .Values.deployment.hpa.targetMemoryType }}
  {{- if eq .Values.deployment.hpa.targetMemoryType "AverageValue" }}
  averageValue: {{ .Values.deployment.hpa.targetMemory }}
  {{- else }}
  averageUtilization: {{ .Values.deployment.hpa.targetMemory }}
  {{- end }}
```

`targetMemoryType` defaults to `Utilization`, so nothing changes for percentage consumers. The `targetMemory` doc comment now states which unit each mode expects — previously it said "Target Memory usage (Mi)" while the template required a percentage, which is how these values got written wrong in the first place.

## Backwards compatibility

`portfolio-calculations` passes `targetMemory: 100` (a percentage) and renders **byte-identical** between 1.5.2 and this branch. `helm lint` passes on all four charts.

Verified `AverageValue` mode renders:

```yaml
target:
  type: AverageValue
  averageValue: 350Mi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)