### PR TITLE
fix(go): give a hook job its own ServiceAccount

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.5.2"
+version: "1.6.0"

--- a/charts/go/templates/_application.tpl
+++ b/charts/go/templates/_application.tpl
@@ -141,3 +141,17 @@ same image gets the same configuration.
   value: "{{ .value }}"
 {{- end }}
 {{- end }}
+
+{{/*
+ServiceAccount the job runs as. Defaults to the application's, or to a dedicated
+one named after the job when job.serviceAccount.create is set.
+*/}}
+{{- define "go.job.serviceAccountName" -}}
+{{- if .Values.job.serviceAccount.name -}}
+{{ .Values.job.serviceAccount.name }}
+{{- else if .Values.job.serviceAccount.create -}}
+{{ .Values.job.name }}
+{{- else -}}
+{{ include "go.application.name" . }}
+{{- end -}}
+{{- end }}

--- a/charts/go/templates/job-service-account.yaml
+++ b/charts/go/templates/job-service-account.yaml
@@ -1,0 +1,16 @@
+{{- if and (eq .Values.job.enabled true) .Values.job.serviceAccount.create }}
+{{- $jobAnnotations := .Values.job.annotations | default dict }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "go.job.serviceAccountName" . }}
+  labels:
+    {{- include "go.labels" . | nindent 4 }}
+  annotations:
+    {{- include "go.annotations" . | nindent 4 }}
+    {{- if hasKey $jobAnnotations "helm.sh/hook" }}
+    helm.sh/hook: {{ index $jobAnnotations "helm.sh/hook" | quote }}
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    {{- end }}
+{{- end }}

--- a/charts/go/templates/job.yaml
+++ b/charts/go/templates/job.yaml
@@ -33,7 +33,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Chart.Name }}
     spec:
-      serviceAccountName: {{ include "go.application.name" . }}
+      serviceAccountName: {{ include "go.job.serviceAccountName" . }}
       containers:
         - name: {{ include "go.application.name" . }}
           image: {{ include "go.application.imageURL" . }}

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -171,6 +171,17 @@ job:
     enabled: true
   # -- Args passed to the job container's entrypoint, e.g. `["migrations"]`.
   args: []
+  serviceAccount:
+    # -- Create a ServiceAccount dedicated to the job, named after `job.name`,
+    # instead of reusing the application's. Required when the job runs as a
+    # pre-install hook: hooks are applied before normal resources, so the
+    # application's ServiceAccount does not exist yet and the job cannot schedule
+    # a pod on a first install. The dedicated account mirrors the job's own
+    # `helm.sh/hook` phases at weight -5 so it is created first, and is deleted
+    # once the job succeeds so no dangling identity is left behind.
+    create: false
+    # -- Use an existing ServiceAccount by name instead. Overrides `create`.
+    name: ""
   restartPolicy: "OnFailure"
   backoffLimit: 2
   resources:


### PR DESCRIPTION
`1.5.2` → `1.6.0`. Reworked after review — the first version annotated the *application's* ServiceAccount as a hook, which was the wrong shape. See "Why not..." below.

## Problem

A job running as a `pre-install` hook **cannot schedule a pod on a first install**.

Helm applies hooks before normal resources. `job.yaml` set `serviceAccountName: {{ include "go.application.name" . }}`, but `service-account.yaml` has no hook annotations — so at hook time that account does not exist. The Job object is created, the Job controller's pod creation is rejected with `serviceaccount "…" not found`, it retries indefinitely, and Helm waits:

```
Watching for changes to Job tenancy-go-migrations with timeout of 10m0s
tenancy-go-migrations: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
...
Error: failed pre-install: timed out waiting for the condition
release tenancy-go failed, and has been uninstalled due to atomic being set
```

`active: 0` throughout is the tell — no pod was ever created, rather than one starting and failing.

**Upgrades are unaffected**, since the account exists from the previous release. Only a service's very first install with a hook job hits it, and `job.enabled` defaults false, so nothing has until now.

## Change

```yaml
job:
  serviceAccount:
    create: false   # new
    name: ""        # new — use an existing account instead
```

With `create: true`, a ServiceAccount named after `job.name` is created **for the job alone**, mirroring the job's own `helm.sh/hook` phases at `hook-weight: "-5"` so it is applied first, with `before-hook-creation` so repeat installs don't collide.

Rendering with `job.serviceAccount.create=true`:

```
tenancy-go               normal resource
tenancy-go-migrations    helm.sh/hook, helm.sh/hook-weight, helm.sh/hook-delete-policy
```

The job runs as `tenancy-go-migrations`; the Deployment still runs as `tenancy-go`.

## Why not annotate the application's ServiceAccount as a hook

That was v1 of this PR. Annotating a hook's prerequisites is a recognised Helm pattern, but it's wrong for an account the **long-lived Deployment also uses**: hook resources sit outside the release manifest, so `helm uninstall` leaves it behind and the release stops tracking it. Hook lifecycle would be a lie about the object.

A job-scoped account is genuinely ephemeral, so hook lifecycle describes it accurately — and the application's account is untouched.

When the job is *not* a hook, the new account is a plain resource and Helm's kind ordering already places ServiceAccount before Job, so no annotations are emitted at all.

## Consumer note

A dedicated account needs whatever trust the job requires. For Vault-injected jobs that means the Kubernetes auth role must bind it too — `infrastructure-modules-vault-secrets` already supports this via `extra_service_accounts`.

## Backwards compatibility

Defaults leave the job on the application's account, exactly as before. `portfolio-calculations`' real demo values render **byte-identical** between 1.5.2 and this branch. `helm lint` passes on all four charts.

`php`, `node` and `python` share the same structure, so the same first-install trap exists there. No consumer is exposed — none sets a hook job — but worth porting if one does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)