### PR TITLE
feat(go): allow annotations on the job's pod template

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.5.2"
+version: "1.6.0"

--- a/charts/go/templates/job.yaml
+++ b/charts/go/templates/job.yaml
@@ -9,6 +9,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with .Values.job.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if eq .Values.job.vault.enabled true }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/agent-pre-populate: "true"

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -166,7 +166,15 @@ istio:
 job:
   enabled: false
   name: ""
+  # -- Annotations on the Job object itself, e.g. `helm.sh/hook`.
   annotations:
+  # -- Annotations on the job's **pod** template. Needed for anything the pod
+  # rather than the Job is evaluated for — most commonly
+  # `sidecar.istio.io/inject: "false"`, since a job pod's container can start
+  # before the Envoy sidecar is listening and outbound connections are then
+  # refused, and the sidecar would otherwise keep running and stop the pod ever
+  # reaching Completed.
+  podAnnotations: {}
   vault:
     enabled: true
   # -- Args passed to the job container's entrypoint, e.g. `["migrations"]`.

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -166,14 +166,10 @@ istio:
 job:
   enabled: false
   name: ""
-  # -- Annotations on the Job object itself, e.g. `helm.sh/hook`.
   annotations:
-  # -- Annotations on the job's **pod** template. Needed for anything the pod
-  # rather than the Job is evaluated for — most commonly
-  # `sidecar.istio.io/inject: "false"`, since a job pod's container can start
-  # before the Envoy sidecar is listening and outbound connections are then
-  # refused, and the sidecar would otherwise keep running and stop the pod ever
-  # reaching Completed.
+  # -- Annotations on the job's **pod** template, e.g.
+  # `sidecar.istio.io/inject: "false"` — injection is decided from the pod, not
+  # the Job.
   podAnnotations: {}
   vault:
     enabled: true


### PR DESCRIPTION
`1.5.2` → `1.6.0`. Found by a migrations job failing to reach its database.

## Problem

The job's pod template only ever gets the Vault annotations:

```yaml
spec:
  template:
    metadata:
      annotations:
        {{- if eq .Values.job.vault.enabled true }}
        vault.hashicorp.com/...
```

`job.annotations` lands on the **Job** object, so there's no way to set anything the **pod** is evaluated for. The one that matters is `sidecar.istio.io/inject: "false"`.

Without it, a job pod in an istio-injected namespace gets an Envoy sidecar, and two things go wrong:

1. The container can start **before Envoy is listening**. iptables already redirects its outbound traffic, so connections are refused — which surfaces as a database error that looks like a network or credentials problem:
   ```
   failed to connect to `user=tenancy database=tenancy`:
   10.28.96.173:5432 dial error: dial tcp ...: connect: connection refused
   ```
2. The sidecar **keeps running** after the container exits, so the pod never reaches `Completed`, the Job never succeeds, and a hook job makes helm wait out its full timeout.

This is established practice rather than a novel workaround — `portfolio`'s own `migration-job.yaml` sets this exact annotation on its pod template.

## Change

```yaml
job:
  podAnnotations: {}   # new
```

Rendered with `job.podAnnotations.sidecar\.istio\.io/inject: "false"`:

```yaml
    metadata:
      annotations:
        sidecar.istio.io/inject: "false"
        vault.hashicorp.com/agent-inject: "true"
        ...
```

Vault injection is unaffected — that's the vault-agent-injector, independent of Istio.

## Backwards compatibility

`podAnnotations` defaults to `{}`, so the block renders exactly as before. `portfolio-calculations`' real demo values render **byte-identical** between 1.5.2 and this branch. `helm lint` passes on all four charts.

`php`, `node` and `python` have the same limitation. Not touched here — they version independently — but the same trap applies to any job they run in a meshed namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)