### PR TITLE
HETO-43: stop the horizon host-rewrite filter faulting on requests without the header

### DIFF
--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.4.3"
+version: "1.4.4"

--- a/charts/php/templates/horizon/envoy-filter-forward-host-to-host.yaml
+++ b/charts/php/templates/horizon/envoy-filter-forward-host-to-host.yaml
@@ -27,10 +27,13 @@ spec:
             "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
             inlineCode: |
               function envoy_on_request(request_handle)
-                headers = request_handle:headers()
-                request_handle:logWarn("envoy_on_request")
-                host = headers:get("x-forwarded-host")
-                request_handle:logWarn("envoy_on_request: " .. host)
-                headers:replace("host", host)
+                local headers = request_handle:headers()
+                local host = headers:get("x-forwarded-host")
+                -- Health checks and in-mesh callers arrive without the header.
+                -- Concatenating a nil host raised, faulting the filter for those
+                -- requests rather than passing them through untouched.
+                if host ~= nil and host ~= "" then
+                  headers:replace("host", host)
+                end
               end
 {{- end }}


### PR DESCRIPTION
headers:get("x-forwarded-host") returns nil for anything that arrives without it — health checks, in-mesh callers — and the log line concatenated that nil, which raises and faults the filter for the request rather than passing it through untouched.

Guarded, and the two per-request logWarn calls dropped: they emitted two lines for every request in perpetuity, the second containing a caller-controlled header value.