### PR TITLE
HETO-43: make the topology spread constraint select the pods it is meant to

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.6.0"
+version: "1.7.0"

--- a/charts/go/templates/_deployment.tpl
+++ b/charts/go/templates/_deployment.tpl
@@ -5,7 +5,7 @@
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
     labelSelector:
       matchLabels:
-        app: {{ .Values.application.name | lower }}
+        app.kubernetes.io/name: {{ .Values.application.name | lower }}
 {{- end }}
 
 {{/*

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -64,8 +64,11 @@ spec:
           {{- with .Values.deployment.preStopSleepSeconds }}
           lifecycle:
             preStop:
-              exec:
-                command: ["/bin/sleep", "{{ . }}"]
+              # Native sleep action, not exec: these images are distroless and have
+              # no /bin/sleep, so the exec form failed on every termination and the
+              # drain never happened. Needs Kubernetes 1.29+.
+              sleep:
+                seconds: {{ . }}
           {{- end }}
           volumeMounts:
             - name: tmp

--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "1.3.2"
+version: "1.4.0"

--- a/charts/node/templates/_deployment.tpl
+++ b/charts/node/templates/_deployment.tpl
@@ -5,7 +5,7 @@
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
     labelSelector:
       matchLabels:
-        app: {{ .Values.application.name | lower }}
+        app.kubernetes.io/name: {{ .Values.application.name | lower }}
 {{- end }}
 
 {{/*

--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.4.4"
+version: "1.5.0"

--- a/charts/php/templates/_deployment.tpl
+++ b/charts/php/templates/_deployment.tpl
@@ -5,7 +5,7 @@
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
     labelSelector:
       matchLabels:
-        app: {{ .Values.application.name | lower }}
+        app.kubernetes.io/name: {{ .Values.application.name | lower }}
 {{- end }}
 
 {{- define "php.deployment.nginx.imageURL" -}}

--- a/charts/python/Chart.yaml
+++ b/charts/python/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: python
 description: A simple Helm chart for Python microservices
-version: 0.2.1
+version: 0.3.0

--- a/charts/python/templates/_deployment.tpl
+++ b/charts/python/templates/_deployment.tpl
@@ -5,7 +5,7 @@
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
     labelSelector:
       matchLabels:
-        app: {{ .Values.application.name | lower }}
+        app.kubernetes.io/name: {{ .Values.application.name | lower }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Every chart's spread constraint selected `app: <name>`, but the shared labels apply `app.kubernetes.io/name`. Nothing matched, so the constraint counted zero pods and the scheduler had no spread signal at all: tenancy landed two of three replicas on one node with a third node empty, so losing one node would have taken out two thirds of the service. It has been inert for every service in every environment.

whenUnsatisfiable stays ScheduleAnyway. With a working selector that is already a strong preference, and DoNotSchedule would leave pods Pending under node pressure rather than merely unbalanced — a separate decision, not part of fixing the bug.

The go chart's preStop hook also ran ["/bin/sleep", N] against a distroless image that has no such binary, so it failed on every termination and the drain it exists to provide never happened — endpoints were not given time to propagate before the process died. Replaced with the native sleep lifecycle action, which needs no binary. Requires Kubernetes 1.29+; the clusters run 1.36.