### PR TITLE
HETO-43: scope the spread calculation to the rollout being deployed

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.7.0"
+version: "1.8.0"

--- a/charts/go/templates/_deployment.tpl
+++ b/charts/go/templates/_deployment.tpl
@@ -3,6 +3,12 @@
   - maxSkew: {{ .Values.deployment.topologySpreadConstraints.maxSkew }}
     topologyKey: {{ .Values.deployment.topologySpreadConstraints.topologyKey }}
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
+    # Scopes the skew calculation to the revision being rolled out. Without it the
+    # old ReplicaSet's pods still count while they terminate, so the scheduler
+    # measures balance against a moving target and the new pods land wherever the
+    # stale numbers point. Kubernetes 1.27+.
+    matchLabelKeys:
+      - pod-template-hash
     labelSelector:
       matchLabels:
         app.kubernetes.io/name: {{ .Values.application.name | lower }}

--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "1.4.0"
+version: "1.5.0"

--- a/charts/node/templates/_deployment.tpl
+++ b/charts/node/templates/_deployment.tpl
@@ -3,6 +3,12 @@
   - maxSkew: {{ .Values.deployment.topologySpreadConstraints.maxSkew }}
     topologyKey: {{ .Values.deployment.topologySpreadConstraints.topologyKey }}
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
+    # Scopes the skew calculation to the revision being rolled out. Without it the
+    # old ReplicaSet's pods still count while they terminate, so the scheduler
+    # measures balance against a moving target and the new pods land wherever the
+    # stale numbers point. Kubernetes 1.27+.
+    matchLabelKeys:
+      - pod-template-hash
     labelSelector:
       matchLabels:
         app.kubernetes.io/name: {{ .Values.application.name | lower }}

--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.5.0"
+version: "1.6.0"

--- a/charts/php/templates/_deployment.tpl
+++ b/charts/php/templates/_deployment.tpl
@@ -3,6 +3,12 @@
   - maxSkew: {{ .Values.deployment.topologySpreadConstraints.maxSkew }}
     topologyKey: {{ .Values.deployment.topologySpreadConstraints.topologyKey }}
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
+    # Scopes the skew calculation to the revision being rolled out. Without it the
+    # old ReplicaSet's pods still count while they terminate, so the scheduler
+    # measures balance against a moving target and the new pods land wherever the
+    # stale numbers point. Kubernetes 1.27+.
+    matchLabelKeys:
+      - pod-template-hash
     labelSelector:
       matchLabels:
         app.kubernetes.io/name: {{ .Values.application.name | lower }}

--- a/charts/python/Chart.yaml
+++ b/charts/python/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: python
 description: A simple Helm chart for Python microservices
-version: 0.3.0
+version: 0.4.0

--- a/charts/python/templates/_deployment.tpl
+++ b/charts/python/templates/_deployment.tpl
@@ -3,6 +3,12 @@
   - maxSkew: {{ .Values.deployment.topologySpreadConstraints.maxSkew }}
     topologyKey: {{ .Values.deployment.topologySpreadConstraints.topologyKey }}
     whenUnsatisfiable: {{ .Values.deployment.topologySpreadConstraints.whenUnsatisfiable }}
+    # Scopes the skew calculation to the revision being rolled out. Without it the
+    # old ReplicaSet's pods still count while they terminate, so the scheduler
+    # measures balance against a moving target and the new pods land wherever the
+    # stale numbers point. Kubernetes 1.27+.
+    matchLabelKeys:
+      - pod-template-hash
     labelSelector:
       matchLabels:
         app.kubernetes.io/name: {{ .Values.application.name | lower }}


### PR DESCRIPTION
Fixing the label selector made the constraint real but not effective: tenancy still landed two replicas on one node with a third node empty. whenUnsatisfiable is ScheduleAnyway, so the constraint is a scoring preference the scheduler can outvote — and during a rolling update the old ReplicaSet's pods are still counted while they terminate, so balance is measured against a moving target and the new pods follow stale numbers.

matchLabelKeys: [pod-template-hash] restricts the count to the revision being rolled out, which addresses that mechanism directly. Kubernetes 1.27+; the clusters run 1.36.

Preferred over switching to DoNotSchedule, which would enforce balance but leave pods Pending when no node can satisfy the skew — a worse failure than an uneven one. If this proves insufficient, that remains the next lever.