### PR TITLE
fix(go): make the native preStop sleep opt-in so 1.8.x deploys again

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.8.0"
+version: "1.8.1"

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -64,11 +64,19 @@ spec:
           {{- with .Values.deployment.preStopSleepSeconds }}
           lifecycle:
             preStop:
-              # Native sleep action, not exec: these images are distroless and have
-              # no /bin/sleep, so the exec form failed on every termination and the
-              # drain never happened. Needs Kubernetes 1.29+.
+              {{- if $.Values.deployment.preStopNativeSleep }}
+              # Native sleep action: the only form that works on distroless images
+              # (no /bin/sleep), but the cluster must accept PodLifecycleSleepAction —
+              # our EKS 1.32 clusters currently strip the field in admission and then
+              # reject every pod with "must specify a handler type".
               sleep:
                 seconds: {{ . }}
+              {{- else }}
+              # exec form: deploys on every cluster, but on distroless images the
+              # hook errors at termination and no drain happens.
+              exec:
+                command: ["/bin/sleep", "{{ . }}"]
+              {{- end }}
           {{- end }}
           volumeMounts:
             - name: tmp

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -144,6 +144,12 @@ deployment:
   # -- Seconds to sleep in a preStop hook, letting in-flight requests drain
   # before the container is signalled. Omitted entirely when unset.
   preStopSleepSeconds: ""
+  # -- Render the preStop sleep as Kubernetes' native sleep lifecycle handler
+  # instead of exec'ing /bin/sleep. The native form is the only one that works
+  # on distroless images, but the cluster must accept PodLifecycleSleepAction;
+  # our EKS 1.32 clusters currently strip it in admission and reject every pod,
+  # so it stays opt-in until they support it.
+  preStopNativeSleep: false
 
 destinationRule:
   enabled: true


### PR DESCRIPTION
- go chart 1.8.0 renders `preStopSleepSeconds` as the native `sleep:` lifecycle handler unconditionally; our EKS 1.32 clusters strip that field in admission and reject every pod with `preStop: must specify a handler type`, making any service that sets the value undeployable (tenancy-go's atomic install timed out at 0/3 ready and self-uninstalled)
- Verified on demo-west via `kubectl apply --dry-run=server`: the native handler is rejected in both istio-injected and plain namespaces, so this is cluster-wide, not injector-specific
- Adds `deployment.preStopNativeSleep` (default `false`) selecting the handler form; the default restores the pre-1.8.0 `exec: /bin/sleep` behaviour — deploys everywhere, drains on shell-ful images, no-ops on distroless — i.e. the 1.7.x status quo rather than a new regression
- Services on clusters that accept `PodLifecycleSleepAction` opt in with one value to get the distroless-compatible native form
- No behaviour change for charts that leave `preStopSleepSeconds` unset (no lifecycle block rendered); chart bumped to 1.8.1
- All three render states verified with `helm template` + `helm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)