### PR TITLE
go: label drained pods out of the castai pod-node-lifecycle webhook

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.8.0"
+version: "1.8.1"

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
         aadpodidbinding: {{ .Values.azure.identity.name }}
         {{- end }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if and .Values.deployment.preStopSleepSeconds .Values.deployment.castaiPodNodeLifecycleOptOut }}
+        # The castai pod-node-lifecycle webhook strips the native sleep preStop
+        # handler at admission and the pod is then rejected, so drained pods
+        # carry its opt-out label until CAST AI ships a fix.
+        pod-node-lifecycle.cast.ai/ignore: "true"
+        {{- end }}
     spec:
       {{- include "go.deployment.topologySpreadConstraints" . | nindent 6 }}
       {{ if .Values.deployment.nodeSelector.toleration -}}

--- a/charts/go/values.yaml
+++ b/charts/go/values.yaml
@@ -144,6 +144,15 @@ deployment:
   # -- Seconds to sleep in a preStop hook, letting in-flight requests drain
   # before the container is signalled. Omitted entirely when unset.
   preStopSleepSeconds: ""
+  # -- Label drained pods with the castai pod-node-lifecycle opt-out. Every
+  # published version of that webhook (<= v0.31.0) predates Kubernetes 1.29,
+  # strips the native sleep handler from pods at admission, and the API server
+  # then rejects them with "must specify a handler type" — a configured drain
+  # is undeployable wherever the webhook runs. Only applied when
+  # preStopSleepSeconds is set. Trade-off while labelled: CAST AI stops
+  # steering those pods between spot and on-demand. Set false once CAST AI
+  # ships a fixed webhook.
+  castaiPodNodeLifecycleOptOut: true
 
 destinationRule:
   enabled: true


### PR DESCRIPTION
- Every published `castai/pod-node-lifecycle` version (≤ v0.31.0) predates Kubernetes 1.29 and strips the native `sleep:` preStop handler while mutating pods at admission; the API server then rejects the pod with `preStop: must specify a handler type`, so any service setting `preStopSleepSeconds` cannot deploy wherever that webhook runs (upgrading it to latest was tested on demo-west and does not help)
- The webhook's `objectSelector` honours a per-pod opt-out label (`pod-node-lifecycle.cast.ai/ignore: "true"`); the Deployment pod template now carries it whenever a drain is configured — verified against the live v0.31.0 webhook via `kubectl apply --dry-run=server` (labelled pod with native sleep is admitted; unlabelled is rejected)
- Gated by `deployment.castaiPodNodeLifecycleOptOut` (default `true`): flip to `false` per service once CAST AI ships a webhook built against current Kubernetes libraries
- Scoped to where the bug bites: pods without `preStopSleepSeconds` get no label and keep CAST AI spot/on-demand steering; while labelled, drained pods are not steered — that's the trade-off for having a working drain
- No render change for charts that leave `preStopSleepSeconds` unset; chart bumped to 1.8.1
- All three states verified with `helm template`

🤖 Generated with [Claude Code](https://claude.com/claude-code)