### PR TITLE
HETO43: Align PodDisruptionBudgets across the library charts

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "1.5.0"
+version: "1.6.0"

--- a/charts/node/templates/pdb.yaml
+++ b/charts/node/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.pdb.enabled true }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "node.application.name" . }}

--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.7.0"
+version: "1.8.0"

--- a/charts/python/Chart.yaml
+++ b/charts/python/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: python
 description: A simple Helm chart for Python microservices
-version: 0.4.0
+version: 0.5.0

--- a/charts/python/templates/pdb.yaml
+++ b/charts/python/templates/pdb.yaml
@@ -2,15 +2,15 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "php.application.name" . }}
+  name: {{ include "python.application.name" . }}
   labels:
-    {{- include "php.labels" . | nindent 4 }}
+    {{- include "python.labels" . | nindent 4 }}
   annotations:
-    {{- include "php.annotations" . | nindent 4 }}
+    {{- include "python.annotations" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "php.application.name" . }}
+      app.kubernetes.io/name: {{ include "python.application.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
policy/v1beta1 was deprecated in Kubernetes 1.21 and removed in 1.25, so a cluster newer than that rejects the manifest outright — "no matches for kind PodDisruptionBudget in version policy/v1beta1" — and the whole release fails to install rather than just that object.

It went unnoticed because every chart defaults pdb.enabled to false and no consumer had turned it on, so the template never rendered. The first service to enable one hit it immediately.

python declared pdb in its values but shipped no template at all, so enabling it there was silently inert. It now has the same template as the others.

go was already on policy/v1; the four charts had simply drifted.