### PR TITLE
HETO-43: Run migration jobs on upgrade only

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "1.6.0"
+version: "1.6.1"

--- a/charts/node/templates/migration-job.yaml
+++ b/charts/node/templates/migration-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "node.labels" . | nindent 4 }}
   annotations:
     {{- include "node.annotations" . | nindent 4 }}
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:

--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.8.0"
+version: "1.8.1"

--- a/charts/php/templates/horizon/migration-job.yaml
+++ b/charts/php/templates/horizon/migration-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "php.labels" . | nindent 4 }}
   annotations:
     {{- include "php.annotations" . | nindent 4 }}
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:

--- a/charts/php/templates/migration-job.yaml
+++ b/charts/php/templates/migration-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "php.labels" . | nindent 4 }}
   annotations:
     {{- include "php.annotations" . | nindent 4 }}
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:


### PR DESCRIPTION
The job ran as a pre-install hook, which Helm fires before any regular resource — including the ServiceAccount the job runs as. On a first install the API server therefore refuses to create its pod, "error looking up service account: not found", and the job sits with no pod until the release times out.

It only shows on a genuinely fresh install, which is why environments installed years ago and upgraded since have never seen it.

pre-upgrade alone is what the go chart's consumers already set through values, and what is running successfully today. The consequence is that a first install creates no job at all — a hook whose event never fires is never created — so the caller has to upgrade once for migrations to run.