### PR TITLE
HETO-43: php - move the nginx sidecar to 1.30.4

### DIFF
--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.8.1"
+version: "1.9.0"

--- a/charts/php/README.md
+++ b/charts/php/README.md
@@ -114,7 +114,7 @@ $ helm upgrade horizon . --values uat-values.yaml --namespace horizon
 | nginx.config.clientMaxBodySize | string | `"1M"` |  |
 | nginx.image.pullPolicy | string | `"Always"` |  |
 | nginx.image.repository | string | `"nginx"` |  |
-| nginx.image.tag | string | `"1.21.1-alpine-unprivileged"` |  |
+| nginx.image.tag | string | `"1.30.4-alpine-unprivileged"` |  |
 | nginx.resources.limits.cpu | string | `"100m"` |  |
 | nginx.resources.limits.memory | string | `"128Mi"` |  |
 | nginx.resources.requests.cpu | string | `"10m"` |  |

--- a/charts/php/values.yaml
+++ b/charts/php/values.yaml
@@ -198,7 +198,7 @@ nginx:
     clientMaxBodySize: 1M
   image:
     repository: nginx
-    tag: 1.21.1-alpine-unprivileged
+    tag: 1.30.4-alpine-unprivileged
     pullPolicy: Always
   resources:
     limits:


### PR DESCRIPTION
The pinned 1.21.1 was published in July 2021 and has five years of fixes behind it. 1.30.x is the current stable branch — nginx uses even minor numbers for stable and odd for mainline, so 1.31 would take feature changes on every release, which is not what a reverse proxy in front of php-fpm wants.

No configuration change is needed. The chart's server blocks use listen, proxy_pass, fastcgi_pass, try_files and rewrite, none of which changed in that window. The one deprecation that could have mattered — the listen ... http2 parameter becoming its own directive in 1.25.1 — does not apply, as neither this chart's config nor horizon's enables http2. The unprivileged image keeps its 8080 port and UID 101, so the securityContext and ports are unchanged.