### PR TITLE
HETO-43: Let a service omit a resource request or limit

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.9.0"
+version: "1.9.1"

--- a/charts/go/templates/_global.tpl
+++ b/charts/go/templates/_global.tpl
@@ -36,3 +36,15 @@ sidecar.istio.io/proxyCPULimit: {{ $proxy.cpuLimit | default "2000m" | quote }}
 sidecar.istio.io/proxyMemoryLimit: {{ $proxy.memoryLimit | default "1024Mi" | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "go.resources" -}}
+{{- $out := dict -}}
+{{- range $section, $values := . -}}
+  {{- $kept := dict -}}
+  {{- range $key, $value := $values -}}
+    {{- if $value }}{{- $_ := set $kept $key $value -}}{{- end -}}
+  {{- end -}}
+  {{- if $kept }}{{- $_ := set $out $section $kept -}}{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}

--- a/charts/go/templates/deployment.yaml
+++ b/charts/go/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               containerPort: {{ .Values.deployment.containerPort }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "go.resources" .Values.application.resources | nindent 12 }}
           {{- if .Values.application.startupProbe.enabled }}
           startupProbe:
             {{- include "go.application.probe" (dict "ctx" . "probe" .Values.application.startupProbe) | nindent 12 }}

--- a/charts/go/templates/job.yaml
+++ b/charts/go/templates/job.yaml
@@ -54,7 +54,7 @@ spec:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
           resources:
-            {{- toYaml .Values.job.resources | nindent 12 }}
+            {{- include "go.resources" .Values.job.resources | nindent 12 }}
       restartPolicy: {{ .Values.job.restartPolicy }}
   backoffLimit: {{ .Values.job.backoffLimit }}
   {{- end }}

--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "1.7.0"
+version: "1.7.1"

--- a/charts/node/templates/_global.tpl
+++ b/charts/node/templates/_global.tpl
@@ -36,3 +36,15 @@ sidecar.istio.io/proxyCPULimit: {{ $proxy.cpuLimit | default "2000m" | quote }}
 sidecar.istio.io/proxyMemoryLimit: {{ $proxy.memoryLimit | default "1024Mi" | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "node.resources" -}}
+{{- $out := dict -}}
+{{- range $section, $values := . -}}
+  {{- $kept := dict -}}
+  {{- range $key, $value := $values -}}
+    {{- if $value }}{{- $_ := set $kept $key $value -}}{{- end -}}
+  {{- end -}}
+  {{- if $kept }}{{- $_ := set $out $section $kept -}}{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}

--- a/charts/node/templates/deployment-supervisor.yaml
+++ b/charts/node/templates/deployment-supervisor.yaml
@@ -55,7 +55,7 @@ spec:
             {{- end }}
           resources:
             {{- if .Values.supervisor.resources }}
-            {{- toYaml .Values.supervisor.resources | nindent 12 }}
+            {{- include "node.resources" .Values.supervisor.resources | nindent 12 }}
             {{- else }}
             limits:
               cpu: 500m

--- a/charts/node/templates/deployment.yaml
+++ b/charts/node/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               containerPort: {{ .Values.application.ports.containerPort }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "node.resources" .Values.application.resources | nindent 12 }}
           livenessProbe:
             {{- if eq .Values.application.livenessProbe.type "tcp" }}
             tcpSocket:

--- a/charts/node/templates/job.yaml
+++ b/charts/node/templates/job.yaml
@@ -41,7 +41,7 @@ spec:
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           securityContext: {{ include "node.application.securityContext" . | nindent 12 }}
           resources:
-            {{- toYaml .Values.job.resources | nindent 12 }}
+            {{- include "node.resources" .Values.job.resources | nindent 12 }}
       restartPolicy: {{ .Values.job.restartPolicy }}
   backoffLimit: {{ .Values.job.backoffLimit }}
   {{- end }}

--- a/charts/node/templates/migration-job.yaml
+++ b/charts/node/templates/migration-job.yaml
@@ -46,7 +46,7 @@ spec:
              {{- end }}
           securityContext: {{ include "node.application.securityContext" . | nindent 12 }}
           resources:
-            {{- toYaml .Values.application.migrations.resources | nindent 12 }}
+            {{- include "node.resources" .Values.application.migrations.resources | nindent 12 }}
       restartPolicy: {{ .Values.application.migrations.restartPolicy }}
   backoffLimit: {{ .Values.application.migrations.backoffLimit }}
   {{- end }}

--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.10.0"
+version: "1.10.1"

--- a/charts/php/templates/_global.tpl
+++ b/charts/php/templates/_global.tpl
@@ -36,3 +36,15 @@ sidecar.istio.io/proxyCPULimit: {{ $proxy.cpuLimit | default "2000m" | quote }}
 sidecar.istio.io/proxyMemoryLimit: {{ $proxy.memoryLimit | default "1024Mi" | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "php.resources" -}}
+{{- $out := dict -}}
+{{- range $section, $values := . -}}
+  {{- $kept := dict -}}
+  {{- range $key, $value := $values -}}
+    {{- if $value }}{{- $_ := set $kept $key $value -}}{{- end -}}
+  {{- end -}}
+  {{- if $kept }}{{- $_ := set $out $section $kept -}}{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}

--- a/charts/php/templates/_logging.tpl
+++ b/charts/php/templates/_logging.tpl
@@ -13,7 +13,7 @@ Logging container for php services
   image: {{ include "php.logging.imageURL" . }}
   imagePullPolicy: IfNotPresent
   resources:
-  {{- toYaml .Values.logging.resources | nindent 4 }}
+  {{- include "php.resources" .Values.logging.resources | nindent 4 }}
   securityContext:
     runAsNonRoot: true
     readOnlyRootFilesystem: true

--- a/charts/php/templates/cronjob.yaml
+++ b/charts/php/templates/cronjob.yaml
@@ -51,7 +51,7 @@ spec:
               args: [{{ .Values.cron.args }}]
               securityContext: {{ include "php.application.securityContext" . | nindent 16 }}
               resources:
-                {{- toYaml .Values.cron.resources | nindent 16 }}
+                {{- include "php.resources" .Values.cron.resources | nindent 16 }}
               
               volumeMounts:
                 - name: fpm-pool-config-volume

--- a/charts/php/templates/data-feed/deployment-queue.yaml
+++ b/charts/php/templates/data-feed/deployment-queue.yaml
@@ -44,7 +44,7 @@ spec:
               value: "{{.value}}"
             {{- end}}
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "php.resources" .Values.application.resources | nindent 12 }}
           volumeMounts:
             - name: fpm-pool-config-volume
               mountPath: /usr/local/etc/php-fpm.d/www.conf

--- a/charts/php/templates/data-feed/deployment-task-scheduler.yaml
+++ b/charts/php/templates/data-feed/deployment-task-scheduler.yaml
@@ -44,7 +44,7 @@ spec:
               value: "{{.value}}"
             {{- end}}
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "php.resources" .Values.application.resources | nindent 12 }}
           volumeMounts:
             - name: fpm-pool-config-volume
               mountPath: /usr/local/etc/php-fpm.d/www.conf

--- a/charts/php/templates/deployment-supervisor.yaml
+++ b/charts/php/templates/deployment-supervisor.yaml
@@ -56,12 +56,7 @@ spec:
               value: "{{ .value }}"
             {{- end }}
           resources:
-            limits:
-              cpu: {{ .Values.supervisor.resources.limits.cpu }}
-              memory: {{ .Values.supervisor.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.supervisor.resources.requests.cpu }}
-              memory: {{ .Values.supervisor.resources.requests.memory }}
+            {{- include "php.resources" .Values.supervisor.resources | nindent 12 }}
           volumeMounts:
             - name: fpm-pool-config-volume
               mountPath: /usr/local/etc/php-fpm.d/www.conf
@@ -98,7 +93,7 @@ spec:
               value: "{{ .value }}"
             {{- end }}
           resources:
-            {{- toYaml .Values.nightwatch.resources | nindent 12 }}
+            {{- include "php.resources" .Values.nightwatch.resources | nindent 12 }}
           volumeMounts:
             - name: shared-files
               mountPath: /var/www/html

--- a/charts/php/templates/deployment.yaml
+++ b/charts/php/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               value: "{{ .value }}"
             {{- end }}
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "php.resources" .Values.application.resources | nindent 12 }}
           {{- if .Values.application.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
@@ -100,7 +100,7 @@ spec:
             - name: http
               containerPort: 8080
           resources:
-            {{- toYaml .Values.nginx.resources | nindent 12 }}
+            {{- include "php.resources" .Values.nginx.resources | nindent 12 }}
           {{- if .Values.application.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -154,7 +154,7 @@ spec:
               value: "{{ .value }}"
             {{- end }}
           resources:
-            {{- toYaml .Values.nightwatch.resources | nindent 12 }}
+            {{- include "php.resources" .Values.nightwatch.resources | nindent 12 }}
           volumeMounts:
             - name: shared-files
               mountPath: /var/www/html

--- a/charts/php/templates/horizon/migration-job.yaml
+++ b/charts/php/templates/horizon/migration-job.yaml
@@ -41,7 +41,7 @@ spec:
               value: "{{ .value }}"
             {{- end }}
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "php.resources" .Values.application.resources | nindent 12 }}
           volumeMounts:
             - name: php-config-volume
               mountPath: /usr/local/etc/php/php.ini

--- a/charts/php/templates/job.yaml
+++ b/charts/php/templates/job.yaml
@@ -42,7 +42,7 @@ spec:
           args: [{{ .Values.job.args }}]
           securityContext: {{ include "php.application.securityContext" . | nindent 12 }}
           resources:
-            {{- toYaml .Values.job.resources | nindent 12 }}
+            {{- include "php.resources" .Values.job.resources | nindent 12 }}
           {{- if .Values.newrelic.ephemeralPods.enabled }}
           volumeMounts:
             - name: newrelic-log

--- a/charts/php/templates/migration-job.yaml
+++ b/charts/php/templates/migration-job.yaml
@@ -62,7 +62,7 @@ spec:
               {{- end }}
           securityContext: {{ include "php.application.securityContext" . | nindent 12 }}
           resources:
-            {{- toYaml .Values.application.migrations.resources | nindent 12 }}
+            {{- include "php.resources" .Values.application.migrations.resources | nindent 12 }}
       restartPolicy: {{ .Values.application.migrations.restartPolicy }}
       volumes:
         - name: fpm-pool-config-volume

--- a/charts/python/Chart.yaml
+++ b/charts/python/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: python
 description: A simple Helm chart for Python microservices
-version: 0.6.0
+version: 0.6.1

--- a/charts/python/templates/_global.tpl
+++ b/charts/python/templates/_global.tpl
@@ -36,3 +36,15 @@ sidecar.istio.io/proxyCPULimit: {{ $proxy.cpuLimit | default "2000m" | quote }}
 sidecar.istio.io/proxyMemoryLimit: {{ $proxy.memoryLimit | default "1024Mi" | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "python.resources" -}}
+{{- $out := dict -}}
+{{- range $section, $values := . -}}
+  {{- $kept := dict -}}
+  {{- range $key, $value := $values -}}
+    {{- if $value }}{{- $_ := set $kept $key $value -}}{{- end -}}
+  {{- end -}}
+  {{- if $kept }}{{- $_ := set $out $section $kept -}}{{- end -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end -}}

--- a/charts/python/templates/deployment.yaml
+++ b/charts/python/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               value: "{{ .value }}"
             {{- end }}
           resources:
-            {{- toYaml .Values.application.resources | nindent 12 }}
+            {{- include "python.resources" .Values.application.resources | nindent 12 }}
           {{- if .Values.application.livenessProbe.enabled }}
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Every chart defaults each request and limit to an empty value and renders the block with toYaml. Helm coalesces a chart's own values.yaml and drops those empties, but a file passed with -f is merged rather than coalesced and they survive — so a service that simply leaves the cpu limit out gets `cpu: null`, which the API reads as zero and then rejects every request above it:

  Job.batch "horizon-migrations" is invalid:
  spec.template.spec.containers[0].resources.requests:
  Invalid value: "150m": must be less than or equal to cpu limit of 0

Every service in the estate is deployed with -f, so no service could express "no cpu limit" at all. That is the shape wanted now: cpu is compressible, the request already apportions it under contention, and a ceiling below the host's core count cannot stop a burst anyway.

The helper drops empty keys, and a section left with nothing is omitted rather than emitted empty. Applied to all 18 render sites, plus the php supervisor block, which set each key by hand and had the same fault in a form that could not be worked around from values at all.

Charts with a value set are unaffected.