### PR TITLE
HETO-43: let a service override a chart default env var

### DIFF
--- a/charts/go/Chart.yaml
+++ b/charts/go/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: go
 description: A generic chart to be used for all GoLang microservices
-version: "1.9.1"
+version: "1.9.2"

--- a/charts/go/templates/_application.tpl
+++ b/charts/go/templates/_application.tpl
@@ -126,15 +126,25 @@ Extra volumes
 {{/*
 Container environment. Shared by the deployment and the job so a job running the
 same image gets the same configuration.
+
+A default the service also sets is dropped rather than emitted twice — the API
+server rejects a container with two env entries of the same name, so without
+this a service could only avoid the collision by not setting the variable.
 */}}
 {{- define "go.application.env" -}}
-- name: APP_NAME
-  value: {{ .Values.application.name | lower | quote }}
-- name: PLATFORM
-  value: "{{ include "go.cloud.provider" . }}"
+{{- $overridden := dict -}}
+{{- range .Values.application.env }}{{- $_ := set $overridden .name true -}}{{- end }}
+{{- $defaults := list
+    (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+    (dict "name" "PLATFORM" "value" (include "go.cloud.provider" .)) }}
 {{- if eq (include "go.cloud.provider" .) "AWS" }}
-- name: AWS_REGION
-  value: {{ .Values.cloud.region }}
+{{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
+{{- end }}
+{{- range $default := $defaults }}
+{{- if not (hasKey $overridden $default.name) }}
+- name: {{ $default.name }}
+  value: {{ $default.value | quote }}
+{{- end }}
 {{- end }}
 {{- range .Values.application.env }}
 - name: "{{ .name }}"

--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: node
 description: A generic chart to be used for all nodeJS microservices
-version: "1.7.1"
+version: "1.7.2"

--- a/charts/node/templates/_application.tpl
+++ b/charts/node/templates/_application.tpl
@@ -89,3 +89,29 @@ Extra volumes
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Environment for a container: the chart's defaults, then the service's own.
+
+A default the service also sets is dropped rather than emitted twice — the API
+server rejects a container with two env entries of the same name, so without
+this a service could only avoid the collision by not setting the variable at
+all.
+
+Takes a dict of `defaults` (a list of name/value dicts) and `env` (the service's
+application.env), because each workload here starts from a different set.
+*/}}
+{{- define "node.application.env" -}}
+{{- $overridden := dict -}}
+{{- range .env }}{{- $_ := set $overridden .name true -}}{{- end }}
+{{- range $default := .defaults }}
+{{- if not (hasKey $overridden $default.name) }}
+- name: {{ $default.name }}
+  value: {{ $default.value | quote }}
+{{- end }}
+{{- end }}
+{{- range .env }}
+- name: "{{ .name }}"
+  value: "{{ .value }}"
+{{- end }}
+{{- end -}}

--- a/charts/node/templates/deployment-supervisor.yaml
+++ b/charts/node/templates/deployment-supervisor.yaml
@@ -41,18 +41,13 @@ spec:
                 - '-c'
                 - pgrep -a supervisord
           env:
-            - name: PLATFORM
-              value: "{{ include "node.cloud.provider" . }}"
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
+            {{- $defaults := list
+                (dict "name" "PLATFORM" "value" (include "node.cloud.provider" .))
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower)) }}
             {{- if eq (include "node.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
             {{- end }}
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- include "node.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             {{- if .Values.supervisor.resources }}
             {{- include "node.resources" .Values.supervisor.resources | nindent 12 }}

--- a/charts/node/templates/deployment.yaml
+++ b/charts/node/templates/deployment.yaml
@@ -37,30 +37,19 @@ spec:
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           securityContext: {{ include "node.application.securityContext" . | nindent 12 }}
           env:
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: DISABLE_INSTANA
-              value: "true"
-            - name: PLATFORM
-              value: "{{ include "node.cloud.provider" . }}"
-            - name: SENTRY_ENABLED
-              value: "true"
-            - name: SENTRY_ENVIRONMENT
-              value: {{ .Values.cloud.environment }}
-            - name: SENTRY_PROFILING_TRACE_SAMPLE_RATE
-              value: "{{ ternary "0.5" "1" (any (eq .Values.cloud.environment "demo") (eq .Values.cloud.environment "production")) }}"
-            - name: SENTRY_PROFILING_PROFILES_SAMPLE_RATE
-              value: "1"
+            {{- $defaults := list
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "DISABLE_INSTANA" "value" "true")
+                (dict "name" "PLATFORM" "value" (include "node.cloud.provider" .))
+                (dict "name" "SENTRY_ENABLED" "value" "true")
+                (dict "name" "SENTRY_ENVIRONMENT" "value" .Values.cloud.environment)
+                (dict "name" "SENTRY_PROFILING_TRACE_SAMPLE_RATE" "value" (ternary "0.5" "1" (any (eq .Values.cloud.environment "demo") (eq .Values.cloud.environment "production"))))
+                (dict "name" "SENTRY_PROFILING_PROFILES_SAMPLE_RATE" "value" "1") }}
             {{- if eq (include "node.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
             {{- end }}
-            - name: NODE_OPTIONS
-              value: "--max-http-header-size={{ .Values.application.nodeOptions.maxHttpHeaderSize | default 65536 }}{{- if .Values.application.nodeOptions.maxOldSpaceSize }} --max-old-space-size={{ .Values.application.nodeOptions.maxOldSpaceSize }}{{- end }}"
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- $defaults = append $defaults (dict "name" "NODE_OPTIONS" "value" (printf "--max-http-header-size=%v%s" (.Values.application.nodeOptions.maxHttpHeaderSize | default 65536) (ternary (printf " --max-old-space-size=%v" .Values.application.nodeOptions.maxOldSpaceSize) "" (not (empty .Values.application.nodeOptions.maxOldSpaceSize))))) }}
+            {{- include "node.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.application.ports.containerPort }}

--- a/charts/node/templates/migration-job.yaml
+++ b/charts/node/templates/migration-job.yaml
@@ -30,20 +30,14 @@ spec:
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           args: ["{{.Values.application.migrations.args }}"]
           env:
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: DISABLE_INSTANA
-              value: "TRUE"
-            - name: PLATFORM
-              value: "{{ include "node.cloud.provider" . }}"
-             {{- if eq (include "node.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
-             {{- end }}
-             {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-             {{- end }}
+            {{- $defaults := list
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "DISABLE_INSTANA" "value" "TRUE")
+                (dict "name" "PLATFORM" "value" (include "node.cloud.provider" .)) }}
+            {{- if eq (include "node.cloud.provider" .) "AWS" }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
+            {{- end }}
+            {{- include "node.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           securityContext: {{ include "node.application.securityContext" . | nindent 12 }}
           resources:
             {{- include "node.resources" .Values.application.migrations.resources | nindent 12 }}

--- a/charts/php/Chart.yaml
+++ b/charts/php/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: php
 description: A generic chart to be used for all PHP microservices
-version: "1.10.2"
+version: "1.10.3"

--- a/charts/php/templates/_application.tpl
+++ b/charts/php/templates/_application.tpl
@@ -89,3 +89,28 @@ Extra volumes
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Environment for a container: the chart's defaults, then the service's own.
+
+A default the service also sets is dropped rather than emitted twice — the API
+server rejects a container with two env entries of the same name, so without
+this a service could only avoid the collision by not setting the variable.
+
+Takes a dict of `defaults` (a list of name/value dicts) and `env` (the service's
+application.env), because each workload here starts from a different set.
+*/}}
+{{- define "php.application.env" -}}
+{{- $overridden := dict -}}
+{{- range .env }}{{- $_ := set $overridden .name true -}}{{- end }}
+{{- range $default := .defaults }}
+{{- if not (hasKey $overridden $default.name) }}
+- name: {{ $default.name }}
+  value: {{ $default.value | quote }}
+{{- end }}
+{{- end }}
+{{- range .env }}
+- name: "{{ .name }}"
+  value: "{{ .value }}"
+{{- end }}
+{{- end -}}

--- a/charts/php/templates/data-feed/deployment-queue.yaml
+++ b/charts/php/templates/data-feed/deployment-queue.yaml
@@ -37,12 +37,9 @@ spec:
           args: [ "queue" ]
           securityContext: {{ include "php.application.securityContext" . | nindent 12 }}
           env:
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
-            {{- range .Values.application.env }}
-            - name: "{{.name}}"
-              value: "{{.value}}"
-            {{- end}}
+            {{- $defaults := list
+                (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
+            {{- include "php.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             {{- include "php.resources" .Values.application.resources | nindent 12 }}
           volumeMounts:

--- a/charts/php/templates/data-feed/deployment-task-scheduler.yaml
+++ b/charts/php/templates/data-feed/deployment-task-scheduler.yaml
@@ -37,12 +37,9 @@ spec:
           args: [ "schedule" ]
           securityContext: {{ include "php.application.securityContext" . | nindent 12 }}
           env:
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
-            {{- range .Values.application.env }}
-            - name: "{{.name}}"
-              value: "{{.value}}"
-            {{- end}}
+            {{- $defaults := list
+                (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
+            {{- include "php.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             {{- include "php.resources" .Values.application.resources | nindent 12 }}
           volumeMounts:

--- a/charts/php/templates/deployment-scheduler.yaml
+++ b/charts/php/templates/deployment-scheduler.yaml
@@ -43,20 +43,14 @@ spec:
                 - '-c'
                 - {{ .Values.scheduler.livenessProbe | default "pgrep -a crond" }}
           env:
-            - name: PLATFORM
-              value: "{{ include "php.cloud.provider" . }}"
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: LOG_CHANNEL
-              value: "stderr"
+            {{- $defaults := list
+                (dict "name" "PLATFORM" "value" (include "php.cloud.provider" .))
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "LOG_CHANNEL" "value" "stderr") }}
             {{- if eq (include "php.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
             {{- end }}
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- include "php.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             limits:
               cpu: 500m

--- a/charts/php/templates/deployment-supervisor.yaml
+++ b/charts/php/templates/deployment-supervisor.yaml
@@ -41,20 +41,14 @@ spec:
                 - '-c'
                 - pgrep -a supervisord
           env:
-            - name: PLATFORM
-              value: "{{ include "php.cloud.provider" . }}"
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: LOG_CHANNEL
-              value: "stderr"
+            {{- $defaults := list
+                (dict "name" "PLATFORM" "value" (include "php.cloud.provider" .))
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "LOG_CHANNEL" "value" "stderr") }}
             {{- if eq (include "php.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
             {{- end }}
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- include "php.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             {{- include "php.resources" .Values.supervisor.resources | nindent 12 }}
           volumeMounts:

--- a/charts/php/templates/deployment.yaml
+++ b/charts/php/templates/deployment.yaml
@@ -39,26 +39,17 @@ spec:
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           securityContext: {{ include "php.application.securityContext" . | nindent 12 }}
           env:
-            - name: PLATFORM
-              value: "{{ include "php.cloud.provider" . }}"
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: SENTRY_ENABLED
-              value: "true"
-            - name: SENTRY_TRACES_SAMPLE_RATE
-              value: "{{ ternary "0.5" "1" (any (eq .Values.cloud.environment "demo") (eq .Values.cloud.environment "production")) }}"
-            - name: SENTRY_PROFILES_SAMPLE_RATE
-              value: "1"
-            - name: LOG_CHANNEL
-              value: "stderr"
+            {{- $defaults := list
+                (dict "name" "PLATFORM" "value" (include "php.cloud.provider" .))
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "SENTRY_ENABLED" "value" "true")
+                (dict "name" "SENTRY_TRACES_SAMPLE_RATE" "value" (ternary "0.5" "1" (any (eq .Values.cloud.environment "demo") (eq .Values.cloud.environment "production"))))
+                (dict "name" "SENTRY_PROFILES_SAMPLE_RATE" "value" "1")
+                (dict "name" "LOG_CHANNEL" "value" "stderr") }}
             {{- if eq (include "php.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
             {{- end }}
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- include "php.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             {{- include "php.resources" .Values.application.resources | nindent 12 }}
           {{- if .Values.application.readinessProbe.enabled }}

--- a/charts/php/templates/migration-job.yaml
+++ b/charts/php/templates/migration-job.yaml
@@ -30,20 +30,14 @@ spec:
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           args: ["{{.Values.application.migrations.args }}"]
           env:
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: DISABLE_INSTANA
-              value: "TRUE"
-            - name: PLATFORM
-              value: "{{ include "php.cloud.provider" . }}"
-             {{- if eq (include "php.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
-             {{- end }}
-             {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-             {{- end }}
+            {{- $defaults := list
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "DISABLE_INSTANA" "value" "TRUE")
+                (dict "name" "PLATFORM" "value" (include "php.cloud.provider" .)) }}
+            {{- if eq (include "php.cloud.provider" .) "AWS" }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
+            {{- end }}
+            {{- include "php.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           volumeMounts:
             - name: fpm-pool-config-volume
               mountPath: /usr/local/etc/php-fpm.d/www.conf

--- a/charts/python/Chart.yaml
+++ b/charts/python/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: python
 description: A simple Helm chart for Python microservices
-version: 0.6.1
+version: 0.6.2

--- a/charts/python/templates/_application.tpl
+++ b/charts/python/templates/_application.tpl
@@ -89,3 +89,27 @@ Extra volumes
   {{- end }}
 {{- end }}
 {{- end -}}
+
+
+{{/*
+Environment for a container: the chart's defaults, then the service's own.
+
+A default the service also sets is dropped rather than emitted twice — the API
+server rejects a container with two env entries of the same name, so without
+this a service could only avoid the collision by not setting the variable at
+all.
+*/}}
+{{- define "python.application.env" -}}
+{{- $overridden := dict -}}
+{{- range .env }}{{- $_ := set $overridden .name true -}}{{- end }}
+{{- range $default := .defaults }}
+{{- if not (hasKey $overridden $default.name) }}
+- name: {{ $default.name }}
+  value: {{ $default.value | quote }}
+{{- end }}
+{{- end }}
+{{- range .env }}
+- name: "{{ .name }}"
+  value: "{{ .value }}"
+{{- end }}
+{{- end -}}

--- a/charts/python/templates/deployment.yaml
+++ b/charts/python/templates/deployment.yaml
@@ -43,26 +43,17 @@ spec:
               containerPort: 8000
               protocol: TCP
           env:
-            - name: PLATFORM
-              value: "{{ include "python.cloud.provider" . }}"
-            - name: APP_NAME
-              value: {{ .Values.application.name | lower | quote }}
-            - name: SENTRY_ENABLED
-              value: "true"
-            - name: SENTRY_TRACES_SAMPLE_RATE
-              value: "{{ ternary "0.5" "1" (any (eq .Values.cloud.environment "demo") (eq .Values.cloud.environment "production")) }}"
-            - name: SENTRY_PROFILES_SAMPLE_RATE
-              value: "1"
-            - name: LOG_CHANNEL
-              value: "stderr"
+            {{- $defaults := list
+                (dict "name" "PLATFORM" "value" (include "python.cloud.provider" .))
+                (dict "name" "APP_NAME" "value" (.Values.application.name | lower))
+                (dict "name" "SENTRY_ENABLED" "value" "true")
+                (dict "name" "SENTRY_TRACES_SAMPLE_RATE" "value" (ternary "0.5" "1" (any (eq .Values.cloud.environment "demo") (eq .Values.cloud.environment "production"))))
+                (dict "name" "SENTRY_PROFILES_SAMPLE_RATE" "value" "1")
+                (dict "name" "LOG_CHANNEL" "value" "stderr") }}
             {{- if eq (include "python.cloud.provider" .) "AWS" }}
-            - name: AWS_REGION
-              value: {{ .Values.cloud.region }}
+            {{- $defaults = append $defaults (dict "name" "AWS_REGION" "value" .Values.cloud.region) }}
             {{- end }}
-            {{- range .Values.application.env }}
-            - name: "{{ .name }}"
-              value: "{{ .value }}"
-            {{- end }}
+            {{- include "python.application.env" (dict "defaults" $defaults "env" .Values.application.env) | nindent 12 }}
           resources:
             {{- include "python.resources" .Values.application.resources | nindent 12 }}
           {{- if .Values.application.livenessProbe.enabled }}


### PR DESCRIPTION
Every library chart emits its own env entries and then appends application.env verbatim, so a service that sets one of them produces two entries with the same name. The API server rejects that: installing service-horizon-data failed on `duplicate entries for key [name="SENTRY_ENABLED"]`, and the only way round it was to not set the variable — even though the chart hardcodes SENTRY_ENABLED=true with no way to turn it off.

A default the service also sets is now dropped rather than emitted twice, in all four charts: go through its existing shared helper, node, php and python through a new one, since each of their workloads starts from a different set.

Output is byte-identical for a service that overrides nothing — checked against the published charts for istio-token and horizon-data, including its supervisor and job, and against this branch's base for horizon and core — so nothing already deployed changes.